### PR TITLE
FIX: Load JS via theme_uploads_local path

### DIFF
--- a/javascripts/discourse/api-initializers/discourse-mermaid-theme-component.js
+++ b/javascripts/discourse/api-initializers/discourse-mermaid-theme-component.js
@@ -9,7 +9,7 @@ async function applyMermaid(element, key = "composer") {
     return;
   }
 
-  await loadScript(settings.theme_uploads.mermaid_js);
+  await loadScript(settings.theme_uploads_local.mermaid_js);
 
   window.mermaid.initialize({
     startOnLoad: false,


### PR DESCRIPTION
The regular uploads paths are not allowed under our Content Security Policy. Uploads with `.js` extensions are given an alias under the `/theme-javascripts` route, so we can use that here.