### PR TITLE
FIX: remove injected error element

### DIFF
--- a/javascripts/discourse/api-initializers/discourse-mermaid-theme-component.js
+++ b/javascripts/discourse/api-initializers/discourse-mermaid-theme-component.js
@@ -43,24 +43,21 @@ async function applyMermaid(element, key = "composer") {
       return;
     }
 
-    if (window.mermaid.parse(code.textContent || "")) {
-      const mermaidId = `mermaid_${index}_${key}`;
-      const promise = window.mermaid.render(mermaidId, code.textContent || "");
-      promise
-        .then((object) => {
-          mermaid.innerHTML = object.svg;
-        })
-        .catch((e) => {
-          mermaid.innerText = e?.message || e;
-
-          // mermaid injects an error element, we need to remove it
-          document.getElementById(mermaidId)?.remove();
-        })
-        .finally(() => {
-          mermaid.dataset.processed = true;
-          mermaid.querySelector(".spinner")?.remove();
-        });
-    }
+    const mermaidId = `mermaid_${index}_${key}`;
+    const promise = window.mermaid.render(mermaidId, code.textContent || "");
+    promise
+      .then((object) => {
+        mermaid.innerHTML = object.svg;
+      })
+      .catch((e) => {
+        mermaid.innerText = e?.message || e;
+        // mermaid injects an error element, we need to remove it
+        document.getElementById(mermaidId)?.remove();
+      })
+      .finally(() => {
+        mermaid.dataset.processed = true;
+        mermaid.querySelector(".spinner")?.remove();
+      });
 
     if (key === "composer") {
       discourseDebounce(updateMarkdownHeight, mermaid, index, 500);

--- a/javascripts/discourse/api-initializers/discourse-mermaid-theme-component.js
+++ b/javascripts/discourse/api-initializers/discourse-mermaid-theme-component.js
@@ -44,16 +44,20 @@ async function applyMermaid(element, key = "composer") {
     }
 
     if (window.mermaid.parse(code.textContent || "")) {
-      const promise = window.mermaid.render(
-        `mermaid_${index}_${key}`,
-        code.textContent || ""
-      );
+      const mermaidId = `mermaid_${index}_${key}`;
+      const promise = window.mermaid.render(mermaidId, code.textContent || "");
       promise
         .then((object) => {
           mermaid.innerHTML = object.svg;
         })
         .catch((e) => {
           mermaid.innerText = e?.message || e;
+
+          // mermaid injects an error element, we need to remove it
+          let injectedElement = document.getElementById(mermaidId);
+          if (injectedElement) {
+            injectedElement.parentNode.removeChild(injectedElement);
+          }
         })
         .finally(() => {
           mermaid.dataset.processed = true;

--- a/javascripts/discourse/api-initializers/discourse-mermaid-theme-component.js
+++ b/javascripts/discourse/api-initializers/discourse-mermaid-theme-component.js
@@ -54,10 +54,7 @@ async function applyMermaid(element, key = "composer") {
           mermaid.innerText = e?.message || e;
 
           // mermaid injects an error element, we need to remove it
-          let injectedElement = document.getElementById(mermaidId);
-          if (injectedElement) {
-            injectedElement.parentNode.removeChild(injectedElement);
-          }
+          document.getElementById(mermaidId)?.remove();
         })
         .finally(() => {
           mermaid.dataset.processed = true;


### PR DESCRIPTION
Mermaid has an error renderer we do not use, make sure we clean up.

Previous to this change errors would inject an element on the page which would
show up at the bottom below the footer.
