### PR TITLE
DEV: Use plugin api version 1.13.0

### DIFF
--- a/javascripts/discourse/api-initializers/discourse-mermaid-theme-component.js
+++ b/javascripts/discourse/api-initializers/discourse-mermaid-theme-component.js
@@ -107,7 +107,7 @@ function updateMarkdownHeight(mermaid, index) {
   }
 }
 
-export default apiInitializer("1.15.0", (api) => {
+export default apiInitializer("1.13.0", (api) => {
   // this is a hack as applySurround expects a top level
   // composer key, not possible from a theme
   window.I18n.translations[


### PR DESCRIPTION
Plugin API versions > 1.13 is not released in any beta versions.