### PR TITLE
UX: Make diagrams fixed-height, with fullscreen view

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,14 +1,56 @@
-.cooked pre[data-code-wrap="mermaid"] {
-  overflow-y: auto;
+.mermaid-wrapper {
+  position: relative;
   margin: 1em 0;
-  font-size: var(--font-0);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 450px;
+  aspect-ratio: 16 / 9;
+  height: auto;
 
-  &:not([data-processed="true"]) {
-    // prevents text flashing while loading
-    font-size: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  background-color: var(--primary-50);
+
+  &:first-child {
+    margin-top: 0;
   }
+
+  .mermaid-diagram-controls {
+    position: absolute;
+    display: flex;
+    top: 0;
+    right: 0;
+
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  html.no-touch & .mermaid-diagram-controls {
+    transition: opacity 0.3s;
+    opacity: 0;
+  }
+
+  html.no-touch &:hover .mermaid-diagram-controls {
+    opacity: 1;
+  }
+}
+
+.mermaid-diagram {
+  overflow-y: scroll;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  padding: 1em;
+  box-sizing: border-box;
+
+  & > * {
+    margin: auto;
+    min-height: max-content;
+  }
+}
+
+.d-modal.mermaid-fullscreen {
+  --modal-max-width: 95vw;
 }

--- a/javascripts/discourse/api-initializers/discourse-mermaid-theme-component.js
+++ b/javascripts/discourse/api-initializers/discourse-mermaid-theme-component.js
@@ -1,94 +1,40 @@
 import { apiInitializer } from "discourse/lib/api";
-import discourseDebounce from "discourse/lib/debounce";
-import loadScript from "discourse/lib/load-script";
+import { generateDiagram } from "../components/mermaid-diagram";
+import MermaidInline from "../components/mermaid-inline";
 
-async function applyMermaid(element, key = "composer", container) {
-  const mermaids = element.querySelectorAll("pre[data-code-wrap=mermaid]");
-
-  if (!mermaids.length) {
+function applyMermaid(mermaidPre, helper) {
+  const mermaidSrc = mermaidPre.querySelector("code")?.textContent;
+  if (!mermaidSrc) {
     return;
   }
 
-  await loadScript(settings.theme_uploads_local.mermaid_js);
+  const mermaidWrapper = document.createElement("div");
+  mermaidWrapper.classList.add("mermaid-wrapper");
 
-  window.mermaid.initialize({
-    startOnLoad: false,
-    theme:
-      getComputedStyle(document.body)
-        .getPropertyValue("--scheme-type")
-        .trim() === "dark"
-        ? "dark"
-        : "default",
-  });
+  if (helper?.renderGlimmer) {
+    helper.renderGlimmer(mermaidWrapper, MermaidInline, {
+      src: mermaidSrc,
+    });
+  } else {
+    // Legacy support for parts of core which cannot renderGlimmer. No fullscreen support
+    const mermaidDiagram = document.createElement("div");
+    mermaidDiagram.classList.add("mermaid-diagram");
+    mermaidDiagram.innerHTML = "<div class='spinner'></div>";
+    mermaidWrapper.appendChild(mermaidDiagram);
 
-  mermaids.forEach((mermaid) => {
-    if (mermaid.dataset.processed) {
-      return;
-    }
-
-    const spinner = document.createElement("div");
-    spinner.classList.add("spinner");
-
-    if (mermaid.dataset.codeHeight && key !== "composer") {
-      mermaid.style.height = `${mermaid.dataset.codeHeight}px`;
-    }
-
-    mermaid.append(spinner);
-  });
-
-  mermaids.forEach((mermaid, index) => {
-    const code = mermaid.querySelector("code");
-
-    if (!code) {
-      return;
-    }
-
-    const mermaidId = `mermaid_${index}_${key}`;
-    const promise = window.mermaid.render(mermaidId, code.textContent || "");
-    promise
-      .then((object) => {
-        mermaid.innerHTML = object.svg;
+    generateDiagram(mermaidSrc)
+      .then((svg) => {
+        mermaidDiagram.innerHTML = svg;
       })
-      .catch((e) => {
-        mermaid.innerText = e?.message || e;
-        // mermaid injects an error element, we need to remove it
-        document.getElementById(mermaidId)?.remove();
-      })
-      .finally(() => {
-        mermaid.dataset.processed = true;
-        mermaid.querySelector(".spinner")?.remove();
+      .catch((error) => {
+        const errorDiv = document.createElement("div");
+        errorDiv.classList.add("alert", "alert-error");
+        errorDiv.textContent = error.message;
+        mermaidDiagram.replaceChildren(errorDiv);
       });
-
-    if (key === "composer") {
-      discourseDebounce(updateMarkdownHeight, mermaid, index, container, 500);
-    }
-  });
-}
-
-function updateMarkdownHeight(mermaid, index, container) {
-  const appEvents = container.lookup("service:app-events");
-  const composer = container.lookup("service:composer");
-
-  let height = parseInt(mermaid.getBoundingClientRect().height, 10);
-  let calculatedHeight = parseInt(mermaid.dataset.calculatedHeight, 10);
-
-  if (height === 0) {
-    return;
   }
 
-  if (height !== calculatedHeight) {
-    mermaid.dataset.calculatedHeight = height;
-
-    const regex = /```mermaid((\s*)|.*auto)$/gm;
-    const existing = [...composer.model.reply.matchAll(regex)][index]?.[0];
-
-    appEvents.trigger(
-      `composer:replace-text`,
-      existing,
-      "```mermaid height=" + height + ",auto",
-      { regex, index }
-    );
-  }
+  mermaidPre.replaceWith(mermaidWrapper);
 }
 
 export default apiInitializer("1.13.0", (api) => {
@@ -114,15 +60,15 @@ export default apiInitializer("1.13.0", (api) => {
 
   if (api.decorateChatMessage) {
     api.decorateChatMessage((element) => {
-      applyMermaid(element, `chat_message_${element.id}`, api.container);
+      element
+        .querySelectorAll("pre[data-code-wrap=mermaid]")
+        .forEach((mermaidPre, helper) => applyMermaid(element, helper));
     });
   }
 
-  api.decorateCookedElement(
-    async (elem, helper) => {
-      const id = helper ? `post_${helper.getModel().id}` : "composer";
-      applyMermaid(elem, id, api.container);
-    },
-    { id: "discourse-mermaid-theme-component" }
-  );
+  api.decorateCookedElement((element, helper) => {
+    element
+      .querySelectorAll("pre[data-code-wrap=mermaid]")
+      .forEach((mermaidPre) => applyMermaid(mermaidPre, helper));
+  });
 });

--- a/javascripts/discourse/components/mermaid-diagram.gjs
+++ b/javascripts/discourse/components/mermaid-diagram.gjs
@@ -1,0 +1,80 @@
+import Component from "@glimmer/component";
+import { cached, tracked } from "@glimmer/tracking";
+import { htmlSafe } from "@ember/template";
+import loadingSpinner from "discourse/helpers/loading-spinner";
+import loadScript from "discourse/lib/load-script";
+
+// Todo: move to ember-async-data if/when core adopts it
+class TrackedPromise {
+  @tracked isResolved = false;
+  @tracked isRejected = false;
+  @tracked isPending = true;
+  @tracked value = null;
+  @tracked error = null;
+
+  constructor(promise) {
+    promise
+      .then((value) => {
+        this.isResolved = true;
+        this.isPending = false;
+        this.value = value;
+      })
+      .catch((error) => {
+        this.isRejected = true;
+        this.isPending = false;
+        this.error = error;
+      });
+  }
+}
+
+let loaded = false;
+
+async function loadMermaid() {
+  await loadScript(settings.theme_uploads_local.mermaid_js);
+
+  if (loaded) {
+    return;
+  }
+  loaded = true;
+  window.mermaid.initialize({
+    startOnLoad: false,
+    theme:
+      getComputedStyle(document.body)
+        .getPropertyValue("--scheme-type")
+        .trim() === "dark"
+        ? "dark"
+        : "default",
+  });
+}
+
+let i = 0;
+
+export async function generateDiagram(source) {
+  await loadMermaid();
+  i++;
+  return window.mermaid
+    .render(`mermaid-diagram-${i}`, source)
+    .then((result) => htmlSafe(result.svg));
+}
+
+export default class MermaidDiagram extends Component {
+  @cached
+  get mermaidDiagram() {
+    const src = this.args.src;
+    return new TrackedPromise(generateDiagram(src));
+  }
+
+  <template>
+    <div class="mermaid-diagram">
+      {{#if this.mermaidDiagram.isPending}}
+        {{loadingSpinner}}
+      {{else if this.mermaidDiagram.isResolved}}
+        {{this.mermaidDiagram.value}}
+      {{else if this.mermaidDiagram.isRejected}}
+        <div
+          class="alert alert-error"
+        >{{this.mermaidDiagram.error.message}}</div>
+      {{/if}}
+    </div>
+  </template>
+}

--- a/javascripts/discourse/components/mermaid-fullscreen.gjs
+++ b/javascripts/discourse/components/mermaid-fullscreen.gjs
@@ -1,0 +1,10 @@
+import DModal from "discourse/components/d-modal";
+import MermaidDiagram from "./mermaid-diagram";
+
+const MermaidFullscreen = <template>
+  <DModal @closeModal={{@closeModal}} class="mermaid-fullscreen">
+    <MermaidDiagram @src={{@model.src}} />
+  </DModal>
+</template>;
+
+export default MermaidFullscreen;

--- a/javascripts/discourse/components/mermaid-inline.gjs
+++ b/javascripts/discourse/components/mermaid-inline.gjs
@@ -21,7 +21,7 @@ export default class MermaidInline extends Component {
     <div class="mermaid-diagram-controls">
       <DButton
         @icon="discourse-expand"
-        class="btn-flat"
+        class="btn-flat mermaid-fullscreen-button"
         @action={{this.fullscreen}}
       />
     </div>

--- a/javascripts/discourse/components/mermaid-inline.gjs
+++ b/javascripts/discourse/components/mermaid-inline.gjs
@@ -1,0 +1,31 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import DButton from "discourse/components/d-button";
+import MermaidDiagram from "./mermaid-diagram";
+import MermaidFullscreen from "./mermaid-fullscreen";
+
+export default class MermaidInline extends Component {
+  @service modal;
+
+  @action
+  fullscreen() {
+    this.modal.show(MermaidFullscreen, {
+      model: {
+        src: this.args.data.src,
+      },
+    });
+  }
+
+  <template>
+    <div class="mermaid-diagram-controls">
+      <DButton
+        @icon="discourse-expand"
+        class="btn-flat"
+        @action={{this.fullscreen}}
+      />
+    </div>
+
+    <MermaidDiagram @src={{@data.src}} />
+  </template>
+}

--- a/spec/system/mermaid_spec.rb
+++ b/spec/system/mermaid_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+describe "mermaid theme", type: :system do
+  before { upload_theme_component }
+
+  let(:mermaid_src) { <<~MERMAID }
+    ```mermaid
+      flowchart
+        A --> B --> C
+    ```
+  MERMAID
+
+  let(:post) { Fabricate(:post, raw: mermaid_src) }
+
+  it "renders mermaid diagrams in posts" do
+    visit "/t/#{post.topic.slug}/#{post.topic.id}"
+    expect(page).to have_css "#post_1 .mermaid-wrapper .mermaid-diagram svg"
+
+    find("#post_1 .mermaid-wrapper").hover
+    find("#post_1 .mermaid-fullscreen-button").click
+    expect(page).to have_css ".mermaid-fullscreen .mermaid-diagram svg"
+  end
+
+  it "renders mermaid diagrams in composer preview" do
+    sign_in Fabricate(:admin)
+
+    visit "/latest"
+    find("#create-topic").click
+    find(".d-editor-input").fill_in with: mermaid_src
+  end
+end


### PR DESCRIPTION
The variable-height strategy used by this theme component is complex, and is not providing a good user experience. This commit removes it, and instead sets all mermaid diagrams to have a fixed aspect-ratio of `16:9` when rendered in posts. For tall diagrams, the content will be scrollable. A fullscreen button in the top right allows popping the diagram into a modal.