### PR TITLE
FIX: Composer preview & chat following 98c1fb82

### DIFF
--- a/javascripts/discourse/api-initializers/discourse-mermaid-theme-component.js
+++ b/javascripts/discourse/api-initializers/discourse-mermaid-theme-component.js
@@ -15,8 +15,11 @@ function applyMermaid(mermaidPre, helper) {
     helper.renderGlimmer(mermaidWrapper, MermaidInline, {
       src: mermaidSrc,
     });
+    mermaidPre.replaceWith(mermaidWrapper);
   } else {
     // Legacy support for parts of core which cannot renderGlimmer. No fullscreen support
+    mermaidPre.replaceChildren(mermaidWrapper);
+
     const mermaidDiagram = document.createElement("div");
     mermaidDiagram.classList.add("mermaid-diagram");
     mermaidDiagram.innerHTML = "<div class='spinner'></div>";
@@ -33,8 +36,6 @@ function applyMermaid(mermaidPre, helper) {
         mermaidDiagram.replaceChildren(errorDiv);
       });
   }
-
-  mermaidPre.replaceWith(mermaidWrapper);
 }
 
 export default apiInitializer("1.13.0", (api) => {
@@ -62,7 +63,7 @@ export default apiInitializer("1.13.0", (api) => {
     api.decorateChatMessage((element) => {
       element
         .querySelectorAll("pre[data-code-wrap=mermaid]")
-        .forEach((mermaidPre, helper) => applyMermaid(element, helper));
+        .forEach((mermaidPre, helper) => applyMermaid(mermaidPre, helper));
     });
   }
 


### PR DESCRIPTION
- Mistake in chat implementation caused whole message to be replaced

- Bug in core means we can't remove/replace elements in the root of cooked in the composer preview. Workaround by nesting the div inside the `<pre>`. Not ideal, but the composer preview will support `renderGlimmer` soon