### PR TITLE
UX: Make modal fill screen, and add basic 'click to zoom'

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -35,7 +35,7 @@
 }
 
 .mermaid-diagram {
-  overflow-y: scroll;
+  overflow: scroll;
   height: 100%;
   width: 100%;
   display: flex;
@@ -51,6 +51,17 @@
   }
 }
 
-.d-modal.mermaid-fullscreen {
+.d-modal.mermaid-fullscreen .d-modal__container {
+  width: 100%;
+  height: 100%;
   --modal-max-width: 95vw;
+
+  .d-modal__body {
+    height: 100%;
+  }
+
+  .mermaid-diagram.zoomed > svg {
+    width: auto;
+    height: 100%;
+  }
 }

--- a/javascripts/discourse/components/mermaid-diagram.gjs
+++ b/javascripts/discourse/components/mermaid-diagram.gjs
@@ -62,7 +62,6 @@ export async function generateDiagram(source) {
 
 export default class MermaidDiagram extends Component {
   @tracked zoomed = false;
-  @tracked isRestrictedWidth = false;
 
   @cached
   get mermaidDiagram() {

--- a/javascripts/discourse/components/mermaid-diagram.gjs
+++ b/javascripts/discourse/components/mermaid-diagram.gjs
@@ -1,6 +1,9 @@
 import Component from "@glimmer/component";
 import { cached, tracked } from "@glimmer/tracking";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
 import { htmlSafe } from "@ember/template";
+import concatClass from "discourse/helpers/concat-class";
 import loadingSpinner from "discourse/helpers/loading-spinner";
 import loadScript from "discourse/lib/load-script";
 
@@ -58,14 +61,34 @@ export async function generateDiagram(source) {
 }
 
 export default class MermaidDiagram extends Component {
+  @tracked zoomed = false;
+  @tracked isRestrictedWidth = false;
+
   @cached
   get mermaidDiagram() {
     const src = this.args.src;
     return new TrackedPromise(generateDiagram(src));
   }
 
+  @action
+  toggleZoom(event) {
+    event.preventDefault();
+    if (!this.args.enableZoom) {
+      return;
+    }
+    this.zoomed = !this.zoomed;
+  }
+
   <template>
-    <div class="mermaid-diagram">
+    {{! template-lint-disable no-invalid-interactive }}
+    <div
+      class={{concatClass
+        "mermaid-diagram"
+        (if @enableZoom "zoomable")
+        (if this.zoomed "zoomed")
+      }}
+      {{on "click" this.toggleZoom}}
+    >
       {{#if this.mermaidDiagram.isPending}}
         {{loadingSpinner}}
       {{else if this.mermaidDiagram.isResolved}}

--- a/javascripts/discourse/components/mermaid-fullscreen.gjs
+++ b/javascripts/discourse/components/mermaid-fullscreen.gjs
@@ -3,7 +3,7 @@ import MermaidDiagram from "./mermaid-diagram";
 
 const MermaidFullscreen = <template>
   <DModal @closeModal={{@closeModal}} class="mermaid-fullscreen">
-    <MermaidDiagram @src={{@model.src}} />
+    <MermaidDiagram @src={{@model.src}} @enableZoom={{true}} />
   </DModal>
 </template>;
 


### PR DESCRIPTION
When clicking/tapping to zoom, the diagram will be allowed to occupy its intrinsic width, and you can scroll around as normal. Tapping again will return is to the normal width-constrained rendering