### PR TITLE
FIX: Suppress mermaid-js syntax error messages in DOM

### DIFF
--- a/javascripts/discourse/components/mermaid-diagram.gjs
+++ b/javascripts/discourse/components/mermaid-diagram.gjs
@@ -47,6 +47,7 @@ async function loadMermaid() {
         .trim() === "dark"
         ? "dark"
         : "default",
+    suppressErrorRendering: true,
   });
 }
 

--- a/spec/system/mermaid_spec.rb
+++ b/spec/system/mermaid_spec.rb
@@ -3,29 +3,48 @@
 describe "mermaid theme", type: :system do
   before { upload_theme_component }
 
-  let(:mermaid_src) { <<~MERMAID }
-    ```mermaid
-      flowchart
-        A --> B --> C
-    ```
-  MERMAID
+  context "when rendering valid diagrams" do
+    let(:mermaid_src) { <<~MERMAID }
+      ```mermaid
+        flowchart
+          A --> B --> C
+      ```
+    MERMAID
 
-  let(:post) { Fabricate(:post, raw: mermaid_src) }
+    let(:post) { Fabricate(:post, raw: mermaid_src) }
 
-  it "renders mermaid diagrams in posts" do
-    visit "/t/#{post.topic.slug}/#{post.topic.id}"
-    expect(page).to have_css "#post_1 .mermaid-wrapper .mermaid-diagram svg"
+    it "renders mermaid diagrams in posts" do
+      visit "/t/#{post.topic.slug}/#{post.topic.id}"
+      expect(page).to have_css "#post_1 .mermaid-wrapper .mermaid-diagram svg"
 
-    find("#post_1 .mermaid-wrapper").hover
-    find("#post_1 .mermaid-fullscreen-button").click
-    expect(page).to have_css ".mermaid-fullscreen .mermaid-diagram svg"
+      find("#post_1 .mermaid-wrapper").hover
+      find("#post_1 .mermaid-fullscreen-button").click
+      expect(page).to have_css ".mermaid-fullscreen .mermaid-diagram svg"
+    end
+
+    it "renders mermaid diagrams in composer preview" do
+      sign_in Fabricate(:admin)
+
+      visit "/latest"
+      find("#create-topic").click
+      find(".d-editor-input").fill_in with: mermaid_src
+    end
   end
 
-  it "renders mermaid diagrams in composer preview" do
-    sign_in Fabricate(:admin)
+  context "when rendering diagrams with invalid syntax" do
+    let(:invalid_mermaid_src) { <<~MERMAID }
+      ```mermaid
+        flowchart
+          A -
+      ```
+    MERMAID
 
-    visit "/latest"
-    find("#create-topic").click
-    find(".d-editor-input").fill_in with: mermaid_src
+    it "shows controlled error message for invalid syntax" do
+      post = Fabricate(:post, raw: invalid_mermaid_src)
+      visit "/t/#{post.topic.slug}/#{post.topic.id}"
+
+      expect(page).to have_css "#post_1 .mermaid-wrapper .alert.alert-error"
+      expect(page).not_to have_css "svg[id^='mermaid-diagram-'][aria-roledescription='error']"
+    end
   end
 end


### PR DESCRIPTION
By default, mermaid-js injects syntax error messages into the DOM when parsing fails. Since we already render our own error, this change suppresses the redundant, incorrectly positioned message injected by mermaid.

## Before:
![Kapture 2025-09-01 at 14 36 57](https://github.com/user-attachments/assets/f7155cf9-1673-4160-8ea8-7569a4bd02e6)



## After:

![Kapture 2025-09-01 at 14 45 17](https://github.com/user-attachments/assets/4231b0f1-1262-45bb-845d-3332d6a2ef7d)




